### PR TITLE
Update endpoints, params, and request methods for api v2

### DIFF
--- a/lib/zaim.js
+++ b/lib/zaim.js
@@ -82,9 +82,9 @@ Zaim.prototype.setAccessTokenSecret = function(secret) {
  *
  * @param {function} callback
  */
-Zaim.prototype.getCredentials = function(callback) {
-  var url = "https://api.zaim.net/v1/user/verify_credentials.json";
-  this._httpGet(url, callback);
+Zaim.prototype.verify = function(callback) {
+  var url = "https://api.zaim.net/v2/home/user/verify";
+  this._httpGet(url, {}, callback);
 };
 
 /**
@@ -94,12 +94,20 @@ Zaim.prototype.getCredentials = function(callback) {
  * @param {Function} callback
  */
 Zaim.prototype.createPay = function(params, callback) {
-  var url = "https://api.zaim.net/v1/pay/create.json";
+  var url = "https://api.zaim.net/v2/home/money/payment";
   params.date = params.date || this._getCurrentDate();
-  if (!params.category_id || !params.genre_id || !params.price) {
+  if (
+    !params.category_id ||
+    !params.genre_id ||
+    !params.amount ||
+    !params.date
+  ) {
     throw new Error(
       "Invalid parameters.category_id, genre_id and price are necessary."
     );
+  }
+  if (!params.mapping) {
+    params.mapping = 1;
   }
   this._httpPost(url, params, callback);
 };
@@ -111,10 +119,13 @@ Zaim.prototype.createPay = function(params, callback) {
  * @param {Function} callback
  */
 Zaim.prototype.createIncome = function(params, callback) {
-  var url = "https://api.zaim.net/v1/income/create.json";
+  var url = "https://api.zaim.net/v2/home/money/income";
   params.date = params.date || this._getCurrentDate();
-  if (!params.category_id || !params.price) {
+  if (!params.category_id || !params.amount || !params.date) {
     throw new Error("Invalid parameters.category_id and price are necessary.");
+  }
+  if (!params.mapping) {
+    params.mapping = 1;
   }
   this._httpPost(url, params, callback);
 };
@@ -126,12 +137,15 @@ Zaim.prototype.createIncome = function(params, callback) {
  * @param {Function} callback
  */
 Zaim.prototype.getMoney = function(params, callback) {
-  var url = "https://api.zaim.net/v1/money/index.json";
+  var url = "https://api.zaim.net/v2/home/money";
   if (arguments.length === 1) {
     callback = params;
     params = {};
   }
-  this._httpPost(url, params, callback);
+  if (!params.mapping) {
+    params.mapping = 1;
+  }
+  this._httpGet(url, params, callback);
 };
 
 /**
@@ -140,43 +154,16 @@ Zaim.prototype.getMoney = function(params, callback) {
  * @param {object} params
  * @param {Function} callback
  */
-Zaim.prototype.getPayCategories = function(params, callback) {
-  var url = "https://api.zaim.net/v1/category/pay.json";
+Zaim.prototype.getCategories = function(params, callback) {
+  var url = "https://api.zaim.net/v2/home/category";
   if (arguments.length === 1) {
     callback = params;
     params = {};
   }
-  this._httpPost(url, params, callback);
-};
-
-/**
- * Get income categories.
- *
- * @param {object} params
- * @param {Function} callback
- */
-Zaim.prototype.getIncomeCategories = function(params, callback) {
-  var url = "https://api.zaim.net/v1/category/income.json";
-  if (arguments.length === 1) {
-    callback = params;
-    params = {};
+  if (!params.mapping) {
+    params.mapping = 1;
   }
-  this._httpPost(url, params, callback);
-};
-
-/**
- * Get payment genres.
- *
- * @param {object} params
- * @param {Function} callback
- */
-Zaim.prototype.getPayGenres = function(params, callback) {
-  var url = "https://api.zaim.net/v1/genre/pay.json";
-  if (arguments.length === 1) {
-    callback = params;
-    params = {};
-  }
-  this._httpPost(url, params, callback);
+  this._httpGet(url, params, callback);
 };
 
 /**
@@ -185,8 +172,8 @@ Zaim.prototype.getPayGenres = function(params, callback) {
  * @param {function} callback
  */
 Zaim.prototype.getCurrencies = function(callback) {
-  var url = "https://api.zaim.net/v1/currency/index.json";
-  this._httpGet(url, callback);
+  var url = "https://api.zaim.net/v2/currency";
+  this._httpGet(url, {}, callback);
 };
 
 /**
@@ -196,10 +183,15 @@ Zaim.prototype.getCurrencies = function(callback) {
  * @param {string} url
  * @param {Function} callback
  */
-Zaim.prototype._httpGet = function(url, callback) {
+Zaim.prototype._httpGet = function(url, params, callback) {
   if (!this.token || !this.secret) {
     throw new Error("accessToken and tokenSecret must be configured.");
   }
+  url += "?";
+  Object.keys(params).forEach(function(key) {
+    url += key + "=" + params[key] + "&";
+  });
+  url.slice(0, -1);
   this.client.get(url, this.token, this.secret, function(err, data) {
     if (err) {
       throw err;

--- a/lib/zaim.js
+++ b/lib/zaim.js
@@ -98,7 +98,7 @@ Zaim.prototype.createPay = function(params, callback) {
   params.date = params.date || this._getCurrentDate();
   if (!params.category_id || !params.genre_id || !params.amount) {
     throw new Error(
-      "Invalid parameters.category_id, genre_id and price are necessary."
+      "Invalid parameters.category_id, genre_id and amount are necessary."
     );
   }
   if (!params.mapping) {
@@ -117,7 +117,7 @@ Zaim.prototype.createIncome = function(params, callback) {
   var url = "https://api.zaim.net/v2/home/money/income";
   params.date = params.date || this._getCurrentDate();
   if (!params.category_id || !params.amount) {
-    throw new Error("Invalid parameters.category_id and price are necessary.");
+    throw new Error("Invalid parameters.category_id and amount are necessary.");
   }
   if (!params.mapping) {
     params.mapping = 1;

--- a/lib/zaim.js
+++ b/lib/zaim.js
@@ -96,12 +96,7 @@ Zaim.prototype.verify = function(callback) {
 Zaim.prototype.createPay = function(params, callback) {
   var url = "https://api.zaim.net/v2/home/money/payment";
   params.date = params.date || this._getCurrentDate();
-  if (
-    !params.category_id ||
-    !params.genre_id ||
-    !params.amount ||
-    !params.date
-  ) {
+  if (!params.category_id || !params.genre_id || !params.amount) {
     throw new Error(
       "Invalid parameters.category_id, genre_id and price are necessary."
     );
@@ -121,7 +116,7 @@ Zaim.prototype.createPay = function(params, callback) {
 Zaim.prototype.createIncome = function(params, callback) {
   var url = "https://api.zaim.net/v2/home/money/income";
   params.date = params.date || this._getCurrentDate();
-  if (!params.category_id || !params.amount || !params.date) {
+  if (!params.category_id || !params.amount) {
     throw new Error("Invalid parameters.category_id and price are necessary.");
   }
   if (!params.mapping) {

--- a/lib/zaim.js
+++ b/lib/zaim.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-var oauth = require('oauth');
+var oauth = require("oauth");
 
 /**
  * Constructor.
@@ -19,11 +19,11 @@ function Zaim(params) {
   this.secret = params.accessTokenSecret;
   this.callback = params.callback;
   this.client = new oauth.OAuth(
-    'https://api.zaim.net/v1/auth/request',
-    'https://api.zaim.net/v1/auth/access',
+    "https://api.zaim.net/v2/auth/request",
+    "https://api.zaim.net/v2/auth/access",
     this.consumerKey,
     this.consumerSecret,
-    '1.0',
+    "1.0",
     this.callback,
     "HMAC-SHA1"
   );
@@ -42,7 +42,7 @@ Zaim.prototype.getAuthorizationUrl = function(callback) {
   this.client.getOAuthRequestToken(function(err, token, secret) {
     that.token = token;
     that.secret = secret;
-    callback('https://www.zaim.net/users/auth?oauth_token=' + that.token);
+    callback("https://auth.zaim.net/users/auth?oauth_token=" + that.token);
   });
 };
 
@@ -97,7 +97,9 @@ Zaim.prototype.createPay = function(params, callback) {
   var url = "https://api.zaim.net/v1/pay/create.json";
   params.date = params.date || this._getCurrentDate();
   if (!params.category_id || !params.genre_id || !params.price) {
-    throw new Error("Invalid parameters.category_id, genre_id and price are necessary.");
+    throw new Error(
+      "Invalid parameters.category_id, genre_id and price are necessary."
+    );
   }
   this._httpPost(url, params, callback);
 };
@@ -154,7 +156,7 @@ Zaim.prototype.getPayCategories = function(params, callback) {
  * @param {Function} callback
  */
 Zaim.prototype.getIncomeCategories = function(params, callback) {
-  var url = 'https://api.zaim.net/v1/category/income.json';
+  var url = "https://api.zaim.net/v1/category/income.json";
   if (arguments.length === 1) {
     callback = params;
     params = {};
@@ -169,7 +171,7 @@ Zaim.prototype.getIncomeCategories = function(params, callback) {
  * @param {Function} callback
  */
 Zaim.prototype.getPayGenres = function(params, callback) {
-  var url = 'https://api.zaim.net/v1/genre/pay.json';
+  var url = "https://api.zaim.net/v1/genre/pay.json";
   if (arguments.length === 1) {
     callback = params;
     params = {};
@@ -183,7 +185,7 @@ Zaim.prototype.getPayGenres = function(params, callback) {
  * @param {function} callback
  */
 Zaim.prototype.getCurrencies = function(callback) {
-  var url = 'https://api.zaim.net/v1/currency/index.json';
+  var url = "https://api.zaim.net/v1/currency/index.json";
   this._httpGet(url, callback);
 };
 
@@ -202,7 +204,7 @@ Zaim.prototype._httpGet = function(url, callback) {
     if (err) {
       throw err;
     } else {
-      callback(typeof data === 'string' ? JSON.parse(data) : data);
+      callback(typeof data === "string" ? JSON.parse(data) : data);
     }
   });
 };
@@ -223,7 +225,7 @@ Zaim.prototype._httpPost = function(url, params, callback) {
     if (err) {
       throw err;
     } else {
-      callback(typeof data === 'string' ? JSON.parse(data) : data);
+      callback(typeof data === "string" ? JSON.parse(data) : data);
     }
   });
 };
@@ -236,7 +238,14 @@ Zaim.prototype._httpPost = function(url, params, callback) {
  */
 Zaim.prototype._getCurrentDate = function() {
   var date = new Date();
-  return date.getYear() % 1900 + 1900 + '-' + (date.getMonth() + 1) + '-' + date.getDate();
+  return (
+    (date.getYear() % 1900) +
+    1900 +
+    "-" +
+    (date.getMonth() + 1) +
+    "-" +
+    date.getDate()
+  );
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,701 @@
+{
+  "name": "zaim",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ajv": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+      "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "coveralls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
+      "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
+      "dev": true,
+      "requires": {
+        "growl": "1.10.5",
+        "js-yaml": "3.12.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.7",
+        "minimist": "1.2.0",
+        "request": "2.88.0"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "expect.js": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.21"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "6.9.1",
+        "har-schema": "2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jscoverage": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/jscoverage/-/jscoverage-0.3.6.tgz",
+      "integrity": "sha1-aTa58kNd4LSU7z5C+BFVUjcoV7Y=",
+      "dev": true,
+      "requires": {
+        "optimist": "0.3.1",
+        "uglify-js": "1.3.4"
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.37.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "mocha-lcov-reporter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-0.0.1.tgz",
+      "integrity": "sha1-AmcEkdtX7myx/nOS6BNwD24zaiE=",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optimist": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.1.tgz",
+      "integrity": "sha1-ZoDTBWAZOvWlXrZDlIg+17y5jy4=",
+      "dev": true,
+      "requires": {
+        "wordwrap": "0.0.3"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "readline-sync": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",
+      "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.21",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
+      "requires": {
+        "psl": "1.1.31",
+        "punycode": "1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.4.tgz",
+      "integrity": "sha1-KCzsQNtWh5jg7G1x0MmJ0yPwY2s=",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.1"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,37 +1,44 @@
 {
   "name": "zaim",
   "version": "1.0.0",
-  "author":"Shintaro Katafuchi",
+  "author": "Shintaro Katafuchi",
   "readmeFilename": "README.md",
   "description": "Node.js library for the Zaim API.",
   "main": "./lib/zaim",
   "homepage": "http://hotchemi.github.io/zaim.js/",
-  "keywords":["Zaim","Library","Money"],
-  "scripts" : {
-    "test" : "make test-coveralls"
+  "keywords": [
+    "Zaim",
+    "Library",
+    "Money"
+  ],
+  "scripts": {
+    "test": "make test-coveralls"
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/hotchemi/zaim.js.git"
   },
-  "engines":{
-    "node":">= 0.8.0"
+  "engines": {
+    "node": ">= 0.8.0"
   },
   "dependencies": {
     "oauth": "*"
   },
   "devDependencies": {
-    "mocha": "*",
+    "coveralls": "*",
     "expect.js": "*",
-    "jscoverage" : "0.3.6",
-    "mocha-lcov-reporter" : "0.0.1",
-    "coveralls": "*"
+    "jscoverage": "0.3.6",
+    "mocha": "*",
+    "mocha-lcov-reporter": "0.0.1",
+    "readline-sync": "^1.4.9"
   },
   "bugs": {
     "url": "https://github.com/hotchemi/zaim.js/issues"
   },
-  "licenses":[{
-    "type":"MIT",
-    "url":"https://github.com/hotchemi/zaim.js/blob/master/LICENSE"
-  }]
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/hotchemi/zaim.js/blob/master/LICENSE"
+    }
+  ]
 }

--- a/sample.js
+++ b/sample.js
@@ -1,0 +1,28 @@
+const Zaim = require("./lib/zaim");
+var readlineSync = require("readline-sync");
+const zaim = new Zaim({
+  consumerKey: "consumerKey",
+  consumerSecret: "consumerSecret",
+  callback: "callback"
+});
+zaim.getAuthorizationUrl(function(url) {
+  console.log(url);
+  input = readlineSync.question(); //入力待ち
+  zaim.getOAuthAccessToken(input, function(err, token, secret, results) {
+    zaim.setAccessToken(token);
+    zaim.setAccessTokenSecret(secret);
+    console.error(zaim);
+    zaim.getMoney(data => {
+      console.log("------");
+      console.log(data);
+      zaim.getCategories(data => {
+        console.log("------");
+        console.log(data);
+        zaim.getCurrencies(data => {
+          console.log("------");
+          console.log(data);
+        });
+      });
+    });
+  });
+});

--- a/test/zaim.js
+++ b/test/zaim.js
@@ -1,17 +1,17 @@
-var dir = process.env.ZAIM_COVERAGE ? '../lib-cov/' : '../lib/',
-  Zaim = require(dir + 'zaim'),
-  expect = require('expect.js');
+var dir = process.env.ZAIM_COVERAGE ? "../lib-cov/" : "../lib/",
+  Zaim = require(dir + "zaim"),
+  expect = require("expect.js");
 
-describe('Constructor suite', function() {
-  it('should throw a error without consumer key and secret', function() {
+describe("Constructor suite", function() {
+  it("should throw a error without consumer key and secret", function() {
     expect(function() {
       new Zaim({});
     }).to.throwError(function(e) {
-        expect(e.message).to.equal('ConsumerKey and secret must be configured.');
-      });
+      expect(e.message).to.equal("ConsumerKey and secret must be configured.");
+    });
   });
 
-  it('should throw a error without consumer secret', function() {
+  it("should throw a error without consumer secret", function() {
     expect(function() {
       new Zaim({
         consumerKey: "consumerKey"
@@ -19,7 +19,7 @@ describe('Constructor suite', function() {
     }).to.throwError();
   });
 
-  it('should throw a error without consumer key', function() {
+  it("should throw a error without consumer key", function() {
     expect(function() {
       new Zaim({
         consumerSecret: "consumerSecret"
@@ -27,7 +27,7 @@ describe('Constructor suite', function() {
     }).to.throwError();
   });
 
-  it('should not throw a error with valid params', function() {
+  it("should not throw a error with valid params", function() {
     expect(function() {
       new Zaim({
         consumerKey: "consumerKey",
@@ -37,187 +37,211 @@ describe('Constructor suite', function() {
   });
 });
 
-describe('getAuthorizationUrl() suite', function() {
-  it('should throw error without callback', function() {
+describe("getAuthorizationUrl() suite", function() {
+  it("should throw error without callback", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret"
     });
     expect(function() {
       zaim.getAuthorizationUrl();
     }).to.throwError(function(e) {
-        expect(e.message).to.equal('ConsumerKey, secret and callback url must be configured.');
-      });
+      expect(e.message).to.equal(
+        "ConsumerKey, secret and callback url must be configured."
+      );
+    });
   });
 
-  it('should not throw error with valid parameters', function() {
+  it("should not throw error with valid parameters", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret',
-      callback: 'http://zaim.net'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret",
+      callback: "http://zaim.net"
     });
     expect(function() {
       zaim.getAuthorizationUrl();
     }).to.not.throwError();
   });
 
-  it('should match expected RegExp', function() {
+  it("should match expected RegExp", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret',
-      callback: 'http://zaim.net'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret",
+      callback: "http://zaim.net"
     });
 
     zaim.getAuthorizationUrl(function(url) {
-      expect(url).to.match(/^https:\/\/www.zaim.net\/users\/auth\?oauth_token=/);
+      expect(url).to.match(
+        /^https:\/\/www.zaim.net\/users\/auth\?oauth_token=/
+      );
     });
   });
 });
 
-describe('setter suite', function() {
-  it('should equal accessToken', function() {
+describe("setter suite", function() {
+  it("should equal accessToken", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret"
     });
-    zaim.setAccessToken('accessToken');
-    expect(zaim.token).to.equal('accessToken');
+    zaim.setAccessToken("accessToken");
+    expect(zaim.token).to.equal("accessToken");
   });
 
-  it('should equal accessTokenSecret', function() {
+  it("should equal accessTokenSecret", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret"
     });
-    zaim.setAccessTokenSecret('accessTokenSecret')
-    expect(zaim.secret).to.equal('accessTokenSecret');
+    zaim.setAccessTokenSecret("accessTokenSecret");
+    expect(zaim.secret).to.equal("accessTokenSecret");
   });
 });
 
-describe('createPay suite', function() {
-  it('should throw error with empty params', function() {
+describe("createPay suite", function() {
+  it("should throw error with empty params", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret"
     });
     expect(function() {
-      zaim.createPay({}, function(data){});
+      zaim.createPay({}, function(data) {});
     }).to.throwError(function(e) {
-        expect(e.message).to.equal('Invalid parameters.category_id, genre_id and price are necessary.');
-      });
+      expect(e.message).to.equal(
+        "Invalid parameters.category_id, genre_id and amount are necessary."
+      );
+    });
   });
 
-  it('with valid parameters', function() {
+  it("with valid parameters", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret"
     });
     // throw error because set invalid consumer key and secret.
     expect(function() {
-      zaim.createPay({
-        category_id: 'category_id',
-        genre_id: 'genre_id',
-        price: 100,
-        date: '2013-04-10' },
-        function(data, error) {});
+      zaim.createPay(
+        {
+          category_id: "category_id",
+          genre_id: "genre_id",
+          amount: 100,
+          date: "2013-04-10"
+        },
+        function(data, error) {}
+      );
     }).to.throwError(function(e) {
-        expect(e.message).to.not.equal('Invalid parameters.category_id, genre_id and price are necessary.');
-      });
+      expect(e.message).to.not.equal(
+        "Invalid parameters.category_id, genre_id and amount are necessary."
+      );
+    });
   });
 });
 
-describe('createIncome suite', function() {
-  it('should throw error with empty params', function() {
+describe("createIncome suite", function() {
+  it("should throw error with empty params", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret"
     });
     expect(function() {
-      zaim.createIncome({}, function(data){});
+      zaim.createIncome({}, function(data) {});
     }).to.throwError(function(e) {
-        expect(e.message).to.equal('Invalid parameters.category_id and price are necessary.');
-      });
+      expect(e.message).to.equal(
+        "Invalid parameters.category_id and amount are necessary."
+      );
+    });
   });
 
-  it('with valid parameters', function() {
+  it("with valid parameters", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret"
     });
     expect(function() {
-      zaim.createIncome({
-          category_id: 'category_id',
-          price: 100,
-          date: '2013-04-10' },
-        function(data, error){});
+      zaim.createIncome(
+        {
+          category_id: "category_id",
+          amount: 100,
+          date: "2013-04-10"
+        },
+        function(data, error) {}
+      );
     }).to.throwError(function(e) {
-        expect(e.message).to.not.equal('Invalid parameters.category_id and price are necessary.');
-      });
+      expect(e.message).to.not.equal(
+        "Invalid parameters.category_id and amount are necessary."
+      );
+    });
   });
 });
 
-describe('private method suite', function() {
-  it('should throw error without access token and secret', function() {
+describe("private method suite", function() {
+  it("should throw error without access token and secret", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret"
     });
     expect(function() {
-      zaim._httpGet("http://zaim.net", function(data){});
+      zaim._httpGet("http://zaim.net", function(data) {});
     }).to.throwError(function(e) {
-        expect(e.message).to.equal('accessToken and tokenSecret must be configured.');
-      });
+      expect(e.message).to.equal(
+        "accessToken and tokenSecret must be configured."
+      );
+    });
   });
 
-  it('should throw error without access token secret', function() {
+  it("should throw error without access token secret", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret',
-      accessToken: 'accessToken'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret",
+      accessToken: "accessToken"
     });
     expect(function() {
-      zaim._httpGet("http://zaim.net/", function(data){});
+      zaim._httpGet("http://zaim.net/", function(data) {});
     }).to.throwError(function(e) {
-        expect(e.message).to.equal('accessToken and tokenSecret must be configured.');
-      });
+      expect(e.message).to.equal(
+        "accessToken and tokenSecret must be configured."
+      );
+    });
   });
 
-  it('should throw error without access token', function() {
+  it("should throw error without access token", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret',
-      accessTokenSecret: 'accessTokenSecret'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret",
+      accessTokenSecret: "accessTokenSecret"
     });
     expect(function() {
-      zaim._httpPost("http://zaim.net/", {}, function(data){});
+      zaim._httpPost("http://zaim.net/", {}, function(data) {});
     }).to.throwError(function(e) {
-        expect(e.message).to.equal('accessToken and tokenSecret must be configured.');
-      });
+      expect(e.message).to.equal(
+        "accessToken and tokenSecret must be configured."
+      );
+    });
   });
 
-  it('should not throw error with access token and secret', function() {
+  it("should not throw error with access token and secret", function() {
     var zaim = new Zaim({
-      consumerKey:'consumerKey',
-      consumerSecret: 'consumerSecret',
-      accessToken: 'accessToken',
-      accessTokenSecret: 'accessTokenSecret'
+      consumerKey: "consumerKey",
+      consumerSecret: "consumerSecret",
+      accessToken: "accessToken",
+      accessTokenSecret: "accessTokenSecret"
     });
     expect(function() {
-      zaim._httpPost("http://zaim.net/", {}, function(data){});
+      zaim._httpPost("http://zaim.net/", {}, function(data) {});
     }).to.not.throwError();
   });
 
-  it('should return valid date today', function() {
+  it("should return valid date today", function() {
     var zaim = new Zaim({
-        consumerKey:'consumerKey',
-        consumerSecret: 'consumerSecret',
-        accessToken: 'accessToken',
-        accessTokenSecret: 'accessTokenSecret'
+        consumerKey: "consumerKey",
+        consumerSecret: "consumerSecret",
+        accessToken: "accessToken",
+        accessTokenSecret: "accessTokenSecret"
       }),
       ymd = new Date(),
-      yy = ymd.getYear() % 1900 + 1900,
+      yy = (ymd.getYear() % 1900) + 1900,
       mm = ymd.getMonth() + 1,
       dd = ymd.getDate();
-    expect(zaim._getCurrentDate()).to.equal(yy + '-' + mm + '-' + dd);
+    expect(zaim._getCurrentDate()).to.equal(yy + "-" + mm + "-" + dd);
   });
 });


### PR DESCRIPTION
zaim.js is very useful, but due to the recent API update, it is outdated. Here I fixed some of the endpoints, parameters, and request methods so that zaim.js can work with the new API.  
This pull request does not include newly-added API endpoints like "POST /v2/home/money/transfer". I am willing to work also on them later if you are ready to accept the pull request. (I'm slightly worried that you ignore this pull request as you are no longer interested in zaim.js.)  

P.S.
I don't mind reverting all double quotation marks to single ones. They all are altered by the formatter. I have a slight preference for single ones, but I don't mind.