### PR TITLE
Fix type AuthParams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zaim",
-  "version": "2.0.0",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zaim",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": "Shintaro Katafuchi",
   "readmeFilename": "README.md",
   "description": "Node.js library for the Zaim API.",

--- a/src/zaim.ts
+++ b/src/zaim.ts
@@ -9,7 +9,7 @@ type AuthParams = {
   consumerSecret: string;
   accessToken?: string;
   accessTokenSecret?: string;
-  callback: string;
+  callback?: string;
 };
 type ItemType = "payment" | "income" | "transfer";
 /**
@@ -31,9 +31,12 @@ export default class Zaim {
 
     this.consumerKey = params.consumerKey;
     this.consumerSecret = params.consumerSecret;
+
     if (params.accessToken && params.accessTokenSecret) {
       this.token = params.accessToken;
       this.secret = params.accessTokenSecret;
+    } else if (!params.callback) {
+      throw new Error("Callback url must be configured.");
     }
     this.client = new oauth.OAuth(
       "https://api.zaim.net/v2/auth/request",

--- a/src/zaim.ts
+++ b/src/zaim.ts
@@ -9,7 +9,7 @@ type AuthParams = {
   consumerSecret: string;
   accessToken: string;
   accessTokenSecret: string;
-  callback: RequestCallbackFunction;
+  callback: string;
 };
 type ItemType = "payment" | "income" | "transfer";
 /**
@@ -22,7 +22,7 @@ export default class Zaim {
   consumerSecret: string;
   token: string;
   secret: string;
-  callback: RequestCallbackFunction;
+  callback: string;
   client = oauth.OAuth;
 
   constructor(params: AuthParams) {

--- a/src/zaim.ts
+++ b/src/zaim.ts
@@ -7,8 +7,8 @@ type RequestCallbackFunction = (data: any) => void;
 type AuthParams = {
   consumerKey: string;
   consumerSecret: string;
-  accessToken: string;
-  accessTokenSecret: string;
+  accessToken?: string;
+  accessTokenSecret?: string;
   callback: string;
 };
 type ItemType = "payment" | "income" | "transfer";
@@ -20,8 +20,8 @@ type ItemType = "payment" | "income" | "transfer";
 export default class Zaim {
   consumerKey: string;
   consumerSecret: string;
-  token: string;
-  secret: string;
+  token!: string;
+  secret!: string;
   client = oauth.OAuth;
 
   constructor(params: AuthParams) {
@@ -31,8 +31,10 @@ export default class Zaim {
 
     this.consumerKey = params.consumerKey;
     this.consumerSecret = params.consumerSecret;
-    this.token = params.accessToken;
-    this.secret = params.accessTokenSecret;
+    if (params.accessToken && params.accessTokenSecret) {
+      this.token = params.accessToken;
+      this.secret = params.accessTokenSecret;
+    }
     this.client = new oauth.OAuth(
       "https://api.zaim.net/v2/auth/request",
       "https://api.zaim.net/v2/auth/access",

--- a/src/zaim.ts
+++ b/src/zaim.ts
@@ -22,7 +22,6 @@ export default class Zaim {
   consumerSecret: string;
   token: string;
   secret: string;
-  callback: string;
   client = oauth.OAuth;
 
   constructor(params: AuthParams) {
@@ -34,14 +33,13 @@ export default class Zaim {
     this.consumerSecret = params.consumerSecret;
     this.token = params.accessToken;
     this.secret = params.accessTokenSecret;
-    this.callback = params.callback;
     this.client = new oauth.OAuth(
       "https://api.zaim.net/v2/auth/request",
       "https://api.zaim.net/v2/auth/access",
       this.consumerKey,
       this.consumerSecret,
       "1.0",
-      this.callback,
+      params.callback,
       "HMAC-SHA1"
     );
   }
@@ -53,10 +51,8 @@ export default class Zaim {
    */
   getAuthorizationUrl(callback: (url: string) => void) {
     var that = this;
-    if (!this.consumerKey || !this.consumerSecret || !this.callback) {
-      throw new Error(
-        "ConsumerKey, secret and callback url must be configured."
-      );
+    if (!this.consumerKey || !this.consumerSecret) {
+      throw new Error("ConsumerKey and secret must be configured.");
     }
     this.client.getOAuthRequestToken(function(
       err: ErrorObject,

--- a/test/zaim.js
+++ b/test/zaim.js
@@ -14,7 +14,8 @@ describe("Constructor suite", function() {
   it("should throw a error without consumer secret", function() {
     expect(function() {
       new Zaim({
-        consumerKey: "consumerKey"
+        consumerKey: "consumerKey",
+        callback: "http://zaim.net"
       });
     }).to.throwError();
   });
@@ -22,7 +23,8 @@ describe("Constructor suite", function() {
   it("should throw a error without consumer key", function() {
     expect(function() {
       new Zaim({
-        consumerSecret: "consumerSecret"
+        consumerSecret: "consumerSecret",
+        callback: "http://zaim.net"
       });
     }).to.throwError();
   });
@@ -31,27 +33,60 @@ describe("Constructor suite", function() {
     expect(function() {
       new Zaim({
         consumerKey: "consumerKey",
+        consumerSecret: "consumerSecret",
+        callback: "http://zaim.net"
+      });
+    }).to.not.throwError();
+  });
+
+  it("should throw error without callback", function() {
+    expect(function() {
+      new Zaim({
+        consumerKey: "consumerKey",
         consumerSecret: "consumerSecret"
+      });
+    }).to.throwError(function(e) {
+      expect(e.message).to.equal("Callback url must be configured.");
+    });
+  });
+
+  it("should throw error without callback when only accessToken is given", function() {
+    expect(function() {
+      new Zaim({
+        consumerKey: "consumerKey",
+        consumerSecret: "consumerSecret",
+        accessToken: "accessToken"
+      });
+    }).to.throwError(function(e) {
+      expect(e.message).to.equal("Callback url must be configured.");
+    });
+  });
+
+  it("should throw error without callback when only accessTokenSecret is given", function() {
+    expect(function() {
+      new Zaim({
+        consumerKey: "consumerKey",
+        consumerSecret: "consumerSecret",
+        accessTokenSecret: "accessTokenSecret"
+      });
+    }).to.throwError(function(e) {
+      expect(e.message).to.equal("Callback url must be configured.");
+    });
+  });
+
+  it("should not throw error even when callback is missing if accessToken and accessTokenSecret are given", function() {
+    expect(function() {
+      new Zaim({
+        consumerKey: "consumerKey",
+        consumerSecret: "consumerSecret",
+        accessToken: "accessToken",
+        accessTokenSecret: "accessTokenSecret"
       });
     }).to.not.throwError();
   });
 });
 
 describe("getAuthorizationUrl() suite", function() {
-  it("should throw error without callback", function() {
-    var zaim = new Zaim({
-      consumerKey: "consumerKey",
-      consumerSecret: "consumerSecret"
-    });
-    expect(function() {
-      zaim.getAuthorizationUrl();
-    }).to.throwError(function(e) {
-      expect(e.message).to.equal(
-        "ConsumerKey, secret and callback url must be configured."
-      );
-    });
-  });
-
   it("should not throw error with valid parameters", function() {
     var zaim = new Zaim({
       consumerKey: "consumerKey",
@@ -82,7 +117,8 @@ describe("setter suite", function() {
   it("should equal accessToken", function() {
     var zaim = new Zaim({
       consumerKey: "consumerKey",
-      consumerSecret: "consumerSecret"
+      consumerSecret: "consumerSecret",
+      callback: "http://zaim.net"
     });
     zaim.setAccessToken("accessToken");
     expect(zaim.token).to.equal("accessToken");
@@ -91,7 +127,8 @@ describe("setter suite", function() {
   it("should equal accessTokenSecret", function() {
     var zaim = new Zaim({
       consumerKey: "consumerKey",
-      consumerSecret: "consumerSecret"
+      consumerSecret: "consumerSecret",
+      callback: "http://zaim.net"
     });
     zaim.setAccessTokenSecret("accessTokenSecret");
     expect(zaim.secret).to.equal("accessTokenSecret");
@@ -102,7 +139,8 @@ describe("createPay suite", function() {
   it("should throw error with empty params", function() {
     var zaim = new Zaim({
       consumerKey: "consumerKey",
-      consumerSecret: "consumerSecret"
+      consumerSecret: "consumerSecret",
+      callback: "http://zaim.net"
     });
     expect(function() {
       zaim.createPay({}, function(data) {});
@@ -116,7 +154,8 @@ describe("createPay suite", function() {
   it("with valid parameters", function() {
     var zaim = new Zaim({
       consumerKey: "consumerKey",
-      consumerSecret: "consumerSecret"
+      consumerSecret: "consumerSecret",
+      callback: "http://zaim.net"
     });
     // throw error because set invalid consumer key and secret.
     expect(function() {
@@ -141,7 +180,8 @@ describe("createIncome suite", function() {
   it("should throw error with empty params", function() {
     var zaim = new Zaim({
       consumerKey: "consumerKey",
-      consumerSecret: "consumerSecret"
+      consumerSecret: "consumerSecret",
+      callback: "http://zaim.net"
     });
     expect(function() {
       zaim.createIncome({}, function(data) {});
@@ -155,7 +195,8 @@ describe("createIncome suite", function() {
   it("with valid parameters", function() {
     var zaim = new Zaim({
       consumerKey: "consumerKey",
-      consumerSecret: "consumerSecret"
+      consumerSecret: "consumerSecret",
+      callback: "http://zaim.net"
     });
     expect(function() {
       zaim.createIncome(
@@ -178,7 +219,8 @@ describe("private method suite", function() {
   it("should throw error without access token and secret", function() {
     var zaim = new Zaim({
       consumerKey: "consumerKey",
-      consumerSecret: "consumerSecret"
+      consumerSecret: "consumerSecret",
+      callback: "http://zaim.net"
     });
     expect(function() {
       zaim._httpGet("http://zaim.net", function(data) {});
@@ -193,7 +235,8 @@ describe("private method suite", function() {
     var zaim = new Zaim({
       consumerKey: "consumerKey",
       consumerSecret: "consumerSecret",
-      accessToken: "accessToken"
+      accessToken: "accessToken",
+      callback: "http://zaim.net"
     });
     expect(function() {
       zaim._httpGet("http://zaim.net/", function(data) {});
@@ -208,7 +251,8 @@ describe("private method suite", function() {
     var zaim = new Zaim({
       consumerKey: "consumerKey",
       consumerSecret: "consumerSecret",
-      accessTokenSecret: "accessTokenSecret"
+      accessTokenSecret: "accessTokenSecret",
+      callback: "http://zaim.net"
     });
     expect(function() {
       zaim._httpPost("http://zaim.net/", {}, function(data) {});


### PR DESCRIPTION
Fix type `AuthParams` not to require `accessToken` and `accessTokenSecret`.  
Also, delete `callback` instance variable as it is only used in `constructor`.